### PR TITLE
fix rendering of area dialog in hidpi displays

### DIFF
--- a/dialogs/areadialog.cpp
+++ b/dialogs/areadialog.cpp
@@ -340,7 +340,7 @@ void AreaDialog::paintEvent(QPaintEvent* e)
   QColor overlayColor(0, 0, 0, mOverlayAlpha);
   QColor textColor = pal.color(QPalette::Active, QPalette::Text);
   QColor textBackgroundColor = pal.color(QPalette::Active, QPalette::Base);
-  painter.drawPixmap(0, 0, mScreenshot->pixmap());
+  mScreenshot->pixmap().setDevicePixelRatio(devicePixelRatio());
   painter.setFont(font);
 
   QRect r = mSelection.normalized().adjusted(0, 0, -1, -1);


### PR DESCRIPTION
Renders the screenshot properly sized onto a hidpi device. Before this
fix the screenshot was rendered magnified by the device pixel ratio
because it assumed the screenshot is non-hdpi and needs therefore
scaling up.

By setting the screenshot's dpr to the same as the QPaintDevice's (QDialog)
we tell QT to not scale the image.