### PR TITLE
fixed incorrect binding

### DIFF
--- a/lightscreenwindow.cpp
+++ b/lightscreenwindow.cpp
@@ -110,15 +110,7 @@ LightscreenWindow::LightscreenWindow(QWidget *parent) :
     mGlobalHotkeys = new UGlobalHotkeys(this);
 
     connect(mGlobalHotkeys, &UGlobalHotkeys::activated, [&](size_t id) {
-        if (id <= 3) {
-            screenshotAction(id);
-        } else if (id == 4) {
-            show();
-        } else if (id == 5) {
-            goToFolder();
-        } else {
-            qWarning() << "Unknown hotkey ID: " << id;
-        }
+        action(id);
     });
 
     // Uploader
@@ -148,16 +140,20 @@ LightscreenWindow::~LightscreenWindow()
 
 void LightscreenWindow::action(int mode)
 {
-    if (mode == 4) {
+    if (mode <= Screenshot::SelectedWindow) {
+        screenshotAction(mode);
+    } else if (mode == ShowMainWindow) {
+        show();
+    } else if (mode == OpenScreenshotFolder) {
         goToFolder();
     } else {
-        show();
+        qWarning() << "Unknown hotkey ID: " << mode;
     }
 }
 
 void LightscreenWindow::areaHotkey()
 {
-    screenshotAction(2);
+    screenshotAction(Screenshot::SelectedArea);
 }
 
 void LightscreenWindow::checkForUpdates()
@@ -348,15 +344,15 @@ void LightscreenWindow::executeArgument(const QString &message)
         os::setForegroundWindow(this);
         qApp->alert(this, 2000);
     } else if (message == "--screen") {
-        screenshotAction();
+        screenshotAction(Screenshot::WholeScreen);
     } else if (message == "--area") {
-        screenshotAction(2);
+        screenshotAction(Screenshot::SelectedArea);
     } else if (message == "--activewindow") {
-        screenshotAction(1);
+        screenshotAction(Screenshot::ActiveWindow);
     } else if (message == "--pickwindow") {
-        screenshotAction(3);
+        screenshotAction(Screenshot::SelectedWindow);
     } else if (message == "--folder") {
-        action(4);
+        action(OpenScreenshotFolder);
     } else if (message == "--uploadlast") {
         uploadLast();
     } else if (message == "--viewhistory") {
@@ -568,7 +564,7 @@ void LightscreenWindow::screenshotActionTriggered(QAction *action)
 
 void LightscreenWindow::screenHotkey()
 {
-    screenshotAction(0);
+    screenshotAction(Screenshot::WholeScreen);
 }
 
 void LightscreenWindow::showHotkeyError(const QStringList &hotkeys)
@@ -858,16 +854,16 @@ void LightscreenWindow::connectHotkeys()
 {
     const QStringList actions = {"screen", "window", "area", "windowPicker", "open", "directory"};
     QStringList failed;
-    size_t i = 0;
+    size_t id = Screenshot::WholeScreen;
 
     for (auto action : actions) {
         if (settings()->value("actions/" + action + "/enabled").toBool()) {
-            if (!mGlobalHotkeys->registerHotkey(settings()->value("actions/" + action + "/hotkey").toString(), i)) {
+            if (!mGlobalHotkeys->registerHotkey(settings()->value("actions/" + action + "/hotkey").toString(), id)) {
                 failed << action;
             }
         }
 
-        i++;
+        id++;
     }
 
     if (!failed.isEmpty()) {

--- a/lightscreenwindow.h
+++ b/lightscreenwindow.h
@@ -40,6 +40,12 @@ class LightscreenWindow : public QMainWindow
     Q_OBJECT
 
 public:
+    enum Action {
+        ShowMainWindow = 5,
+        OpenScreenshotFolder = 6
+    };
+    Q_ENUM(Action)
+
     LightscreenWindow(QWidget *parent = 0);
     ~LightscreenWindow();
 

--- a/tools/screenshot.h
+++ b/tools/screenshot.h
@@ -45,10 +45,11 @@ public:
     Q_ENUM(Naming)
 
     enum Mode {
-        WholeScreen  = 0,
-        ActiveWindow = 1,
-        SelectedArea = 2,
-        SelectedWindow = 3
+        None         = 0,
+        WholeScreen  = 1,
+        ActiveWindow = 2,
+        SelectedArea = 3,
+        SelectedWindow = 4
     };
     Q_ENUM(Mode)
 


### PR DESCRIPTION
From uglobalhotkeys.cpp:
```
 auto ind = Registered.key({ev->detail, (ev->state & ~XCB_MOD_MASK_2)});
 if (ind == 0) // this is not hotkeys
     return false;
```
If the hash contains no item with the value, the function returns a default-constructed key.
Zero value reserved for the whole screen:

```
const QStringList actions = {"screen", "window", "area", "windowPicker", "open", "directory"};
QStringList failed;
size_t i = 0;
 
for (auto action : actions) {
  if (settings()->value("actions/" + action + "/enabled").toBool()) {
      if (!mGlobalHotkeys->registerHotkey(settings()->value("actions/" + action + "/hotkey").toString(), i)) {
```
Whole screenshot button (Print) can not be processed correctly.
All mode values was inсrement