### PR TITLE
Readded active monitor capture

### DIFF
--- a/tools/screenshot.cpp
+++ b/tools/screenshot.cpp
@@ -397,7 +397,7 @@ void Screenshot::grabDesktop()
     QRect geometry;
 
     if (mOptions.currentMonitor) {
-        geometry = QApplication::primaryScreen()->geometry();
+        geometry = QApplication::desktop()->screenGeometry(QCursor::pos());
     } else {
         for (QScreen *screen : QGuiApplication::screens()) {
             geometry = geometry.united(screen->geometry());


### PR DESCRIPTION
Why was this even removed? This was one of the biggest reasons I was using Lightscreen. Would love to see it come back.

The option should be reworded If it was intended to behave the way it currently does (capture primary monitor) or should be a separate option/feature.