### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-##Lightscreen
+## Lightscreen
 [![Build status](https://ci.appveyor.com/api/projects/status/26q7pg1q5u4ukxbg?svg=true)](https://ci.appveyor.com/project/ckaiser/lightscreen) [![Coverity status](https://scan.coverity.com/projects/6066/badge.svg)](https://scan.coverity.com/projects/ckaiser-lightscreen)
 
 A screenshot tool.


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
