### PR TITLE
Fix conflicting symbols in linux build

### DIFF
--- a/tools/screenshot.cpp
+++ b/tools/screenshot.cpp
@@ -43,6 +43,7 @@
 #ifdef Q_OS_LINUX
     #include <QX11Info>
     #include <X11/X.h>
+    #undef Success
     #include <X11/Xlib.h>
 #endif
 


### PR DESCRIPTION
Fixes conflicting symbol "Success", defined as macro in X11/X.h, while also being defined in enum Screenshot::Result.