### PR TITLE
Enable compilation on FreeBSD

### DIFF
--- a/dialogs/optionsdialog.cpp
+++ b/dialogs/optionsdialog.cpp
@@ -57,7 +57,7 @@ OptionsDialog::OptionsDialog(QWidget *parent) :
     ui.setupUi(this);
     setModal(true);
 
-#if defined(Q_OS_LINUX)
+#if defined(Q_OS_LINUX) || defined(Q_OS_FREEBSD)
     // KDE-specific style tweaks.
     if (qApp->style()->objectName() == "oxygen") {
         ui.browsePushButton->setMaximumWidth(30);
@@ -224,7 +224,7 @@ void OptionsDialog::loadSettings()
         ui.optiPngCheckBox->setEnabled(false);
         ui.optiPngLabel->setText("optipng.exe not found");
     }
-#elif defined(Q_OS_LINUX)
+#elif defined(Q_OS_LINUX) || defined(Q_OS_FREEBSD)
     if (!QProcess::startDetached("optipng")) {
         ui.optiPngCheckBox->setChecked(false);
         ui.optiPngCheckBox->setEnabled(false);

--- a/lightscreenwindow.cpp
+++ b/lightscreenwindow.cpp
@@ -177,7 +177,7 @@ void LightscreenWindow::cleanup(const Screenshot::Options &options)
 {
     // Reversing settings
     if (settings()->value("options/hide").toBool()) {
-#ifndef Q_OS_LINUX // X is not quick enough and the notification ends up everywhere but in the icon
+#if !defined(Q_OS_LINUX) && !defined(Q_OS_FREEBSD)  // X is not quick enough and the notification ends up everywhere but in the icon
         if (settings()->value("options/tray").toBool() && mTrayIcon) {
             mTrayIcon->show();
         }
@@ -206,7 +206,7 @@ void LightscreenWindow::cleanup(const Screenshot::Options &options)
     }
 
     if (settings()->value("options/playSound", false).toBool()) {
-        if (options.result == Screenshot::Success) {
+        if (options.result == Screenshot::SuccessLS) {
             QSound::play("sounds/ls.screenshot.wav");
         } else {
 #ifdef Q_OS_WIN
@@ -220,7 +220,7 @@ void LightscreenWindow::cleanup(const Screenshot::Options &options)
 
     updateStatus();
 
-    if (options.result != Screenshot::Success) {
+    if (options.result != Screenshot::SuccessLS) {
         return;
     }
 
@@ -379,7 +379,7 @@ void LightscreenWindow::executeArguments(const QStringList &arguments)
 void LightscreenWindow::notify(const Screenshot::Result &result)
 {
     switch (result) {
-    case Screenshot::Success:
+    case Screenshot::SuccessLS:
         mTrayIcon->setIcon(QIcon(":/icons/lightscreen.yes"));
 
         if (mHasTaskbarButton) {
@@ -481,7 +481,7 @@ void LightscreenWindow::screenshotAction(Screenshot::Mode mode)
     if (optionsHide) {
         hide();
 
-#ifndef Q_OS_LINUX // X is not quick enough and the notification ends up everywhere but in the icon
+#if !defined(Q_OS_LINUX) && !defined(Q_OS_FREEBSD) // X is not quick enough and the notification ends up everywhere but in the icon
         if (mTrayIcon) {
             mTrayIcon->hide();
         }
@@ -647,7 +647,7 @@ void LightscreenWindow::showScreenshotMessage(const Screenshot::Result &result, 
     QString title;
     QString message;
 
-    if (result == Screenshot::Success) {
+    if (result == Screenshot::SuccessLS) {
         title = QFileInfo(fileName).fileName();
 
         if (settings()->value("file/target").toString().isEmpty()) {

--- a/tools/os.h
+++ b/tools/os.h
@@ -28,7 +28,7 @@ class QUrl;
 class QGraphicsEffect;
 class QIcon;
 
-#if defined(Q_OS_LINUX)
+#if defined(Q_OS_LINUX) || defined(Q_OS_FREEBSD)
     typedef unsigned long XID;
     typedef XID Window;
 #endif
@@ -59,7 +59,7 @@ QGraphicsEffect *shadow(const QColor &color = Qt::black, int blurRadius = 6, int
 QIcon icon(const QString &name, QColor backgroundColor = QColor());
 
 // X11-specific functions for the Window Picker
-#if defined(Q_OS_LINUX)
+#if defined(Q_OS_LINUX) || defined(Q_OS_FREEBSD)
     Window findRealWindow(Window w, int depth = 0);
     Window windowUnderCursor(bool includeDecorations = true);
 #endif

--- a/tools/screenshot.cpp
+++ b/tools/screenshot.cpp
@@ -40,7 +40,7 @@
     #include <windows.h>
 #endif
 
-#ifdef Q_OS_LINUX
+#if defined(Q_OS_LINUX) || defined(Q_OS_FREEBSD)
     #include <QX11Info>
     #include <X11/X.h>
     #include <X11/Xlib.h>
@@ -247,7 +247,7 @@ void Screenshot::save()
         QApplication::clipboard()->setPixmap(mPixmap, QClipboard::Clipboard);
 
         if (!mOptions.file) {
-            result = Screenshot::Success;
+            result = Screenshot::SuccessLS;
         }
     }
 
@@ -257,9 +257,9 @@ void Screenshot::save()
         if (name.isEmpty()) {
             result = Screenshot::Cancel;
         } else if (mUnloaded) {
-            result = (QFile::rename(mUnloadFilename, fileName)) ? Screenshot::Success : Screenshot::Failure;
+            result = (QFile::rename(mUnloadFilename, fileName)) ? Screenshot::SuccessLS : Screenshot::Failure;
         } else if (mPixmap.save(fileName, 0, mOptions.quality)) {
-            result = Screenshot::Success;
+            result = Screenshot::SuccessLS;
         } else {
             result = Screenshot::Failure;
         }
@@ -374,7 +374,7 @@ void Screenshot::activeWindow()
     mPixmap = os::grabWindow((WId)GetForegroundWindow());
 #endif
 
-#if defined(Q_OS_LINUX)
+#if defined(Q_OS_LINUX) || defined(Q_OS_FREEBSD)
     Window focus;
     int revert;
 

--- a/tools/screenshot.h
+++ b/tools/screenshot.h
@@ -55,7 +55,7 @@ public:
 
     enum Result {
         Failure = 0,
-        Success = 1,
+        SuccessLS = 1,
         Cancel = 2
     };
     Q_ENUM(Result)

--- a/tools/windowpicker.cpp
+++ b/tools/windowpicker.cpp
@@ -38,7 +38,7 @@
         #define GCL_HICONSM GCLP_HICONSM
     #endif
 
-#elif defined(Q_OS_LINUX)
+#elif defined(Q_OS_LINUX) || defined(Q_OS_FREEBSD)
     #include <QX11Info>
     #include <X11/X.h>
     #include <X11/Xlib.h>
@@ -50,7 +50,7 @@ WindowPicker::WindowPicker() : QWidget(0), mCrosshair(":/icons/picker"), mWindow
 {
 #if defined(Q_OS_WIN)
     setWindowFlags(Qt::SplashScreen | Qt::WindowStaysOnTopHint);
-#elif defined(Q_OS_LINUX)
+#elif defined(Q_OS_LINUX) || defined(Q_OS_FREEBSD)
     setWindowFlags(Qt::WindowStaysOnTopHint);
 #endif
 
@@ -172,7 +172,7 @@ void WindowPicker::mouseMoveEvent(QMouseEvent *event)
     } else {
         mWindowIcon->setPixmap(QPixmap());
     }
-#elif defined(Q_OS_LINUX)
+#elif defined(Q_OS_LINUX) || defined(Q_OS_FREEBSD)
     Window cWindow = os::windowUnderCursor(false);
 
     if (cWindow == mCurrentWindow) {
@@ -276,7 +276,7 @@ void WindowPicker::mouseReleaseEvent(QMouseEvent *event)
         mousePos.y = event->globalY();
 
         HWND nativeWindow = GetAncestor(WindowFromPoint(mousePos), GA_ROOT);
-#elif defined(Q_OS_LINUX)
+#elif defined(Q_OS_LINUX) || defined(Q_OS_FREEBSD)
         Window nativeWindow = os::windowUnderCursor(false);
 #endif
 
@@ -290,7 +290,7 @@ void WindowPicker::mouseReleaseEvent(QMouseEvent *event)
         setWindowFlags(windowFlags() ^ Qt::WindowStaysOnTopHint);
         close();
 
-#ifdef Q_OS_LINUX
+#if defined(Q_OS_LINUX) || defined(Q_OS_FREEBSD)
         emit pixmap(QPixmap::grabWindow(mCurrentWindow));
 #else
         emit pixmap(os::grabWindow((WId)nativeWindow));


### PR DESCRIPTION
Add Q_OS_FREEBSD where needed to make the build on FreeBSD successful.

Rename constant "Success" to "SuccessLS" to avoid naming conflicts.

Builds and runs fine together with the patches for "UGlobalHotkeys" on
FreeBSD with Qt 5.12.